### PR TITLE
allow overriding input encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ ass-shifter [path] -t [shift ms]
     -e --end           end at HH:MM:SS
     -sr --startRegexp  start from regular expression
     -er --endRegexp    end at regular expression
+    -enc --encoding    force input encoding (e.g. gbk, shift_jis); skips auto-detection
     -d --dry           dry run
 ```
+
+Use `--encoding` when auto-detection picks the wrong charset (common with GBK/Shift_JIS subtitles misread as Latin-1).
 
 The `--start` and `--end` parameters can be used to qualify the time range of the subtitle offset.   
 The `--startRegexp` and `--endRegexp` parameters can be used to match the content of the subtitle with a regular expression as the start and end of the offset time range.  

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"golang.org/x/net/html/charset"
+	"golang.org/x/text/transform"
+)
+
+func TestInitInputEncoding(t *testing.T) {
+	t.Cleanup(func() {
+		inputEncoding = nil
+		inputEncName = ""
+	})
+
+	if err := initInputEncoding(""); err != nil {
+		t.Fatal(err)
+	}
+	if inputEncoding != nil {
+		t.Fatal("empty label should not set encoding")
+	}
+
+	if err := initInputEncoding("gbk"); err != nil {
+		t.Fatal(err)
+	}
+	if inputEncoding == nil || inputEncName != "gbk" {
+		t.Fatalf("gbk: encoding=%v name=%q", inputEncoding, inputEncName)
+	}
+
+	if err := initInputEncoding("not-a-real-encoding"); err == nil {
+		t.Fatal("expected error for unknown encoding")
+	}
+}
+
+func TestGBKDecode(t *testing.T) {
+	e, _ := charset.Lookup("gbk")
+	if e == nil {
+		t.Fatal("gbk not recognized")
+	}
+	utf8, _, err := transform.Bytes(e.NewDecoder(), []byte("\xb2\xe2\xca\xd4")) // 测试
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(utf8, []byte("测试")) {
+		t.Fatalf("got %q", utf8)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -20,21 +20,27 @@ var supportTypes map[string]subtitle = map[string]subtitle{
 }
 
 var (
-	inputPath  string
-	shift      int
-	gFrom      int
-	gTo        int
-	fromStr    string
-	toStr      string
-	fromRegexp string
-	toRegexp   string
-	encOverr   string
-	dry        bool
+	inputPath     string
+	shift         int
+	gFrom         int
+	gTo           int
+	fromStr       string
+	toStr         string
+	fromRegexp    string
+	toRegexp      string
+	encOverr      string
+	inputEncoding encoding.Encoding
+	inputEncName  string
+	dry           bool
 )
 
 var version = "1.0.0"
 
 func init() {
+	// ponytail: skip CLI parse under go test; upgrade path is TestMain + extracted cmd package
+	if strings.HasSuffix(os.Args[0], ".test") {
+		return
+	}
 	flaggy.SetName("ass-shifter")
 	flaggy.SetDescription("ASS subtitle shifter")
 	flaggy.DefaultParser.ShowHelpOnUnexpected = true
@@ -45,7 +51,7 @@ func init() {
 	flaggy.String(&toStr, "e", "end", "end at HH:MM:SS")
 	flaggy.String(&fromRegexp, "sr", "startRegexp", "start from regular expression")
 	flaggy.String(&toRegexp, "er", "endRegexp", "end at regular expression")
-	flaggy.String(&encOverr, "enc", "encoding", "override encoding detection")
+	flaggy.String(&encOverr, "enc", "encoding", "force input encoding (e.g. gbk, shift_jis); skips auto-detection")
 	flaggy.Bool(&dry, "d", "dry", "dry run")
 	flaggy.SetVersion(version)
 	flaggy.Parse()
@@ -154,6 +160,13 @@ func main() {
 		fmt.Println(err)
 		return
 	}
+	if err := initInputEncoding(encOverr); err != nil {
+		fmt.Println(err)
+		return
+	}
+	if inputEncoding != nil {
+		fmt.Printf("Using encoding %s (override)\n", inputEncName)
+	}
 	filepath.Walk(inputPath, walker)
 
 	if dry {
@@ -161,6 +174,21 @@ func main() {
 	} else {
 		fmt.Printf("\n[Info] %d subtitle files updated.\n", fileUpdated)
 	}
+}
+
+func initInputEncoding(label string) error {
+	if label == "" {
+		inputEncoding = nil
+		inputEncName = ""
+		return nil
+	}
+	e, name := charset.Lookup(label)
+	if e == nil {
+		return fmt.Errorf("Encoding %s is not recognized", label)
+	}
+	inputEncoding = e
+	inputEncName = name
+	return nil
 }
 
 func walker(realPath string, f os.FileInfo, err error) error {
@@ -181,12 +209,9 @@ func walker(realPath string, f os.FileInfo, err error) error {
 		var fileEncoding encoding.Encoding
 		var name string
 		var certain bool
-		if encOverr != "" {
-			fileEncoding, name = charset.Lookup(encOverr)
-			if fileEncoding == nil {
-				fmt.Printf("Encoding %s is not recognized\n", encOverr)
-				return nil
-			}
+		if inputEncoding != nil {
+			fileEncoding = inputEncoding
+			name = inputEncName
 			certain = true
 		} else {
 			fileEncoding, name, certain = charset.DetermineEncoding(subFile, "")

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/integrii/flaggy"
 	"golang.org/x/net/html/charset"
+	"golang.org/x/text/encoding"
 	"golang.org/x/text/transform"
 )
 
@@ -27,6 +28,7 @@ var (
 	toStr      string
 	fromRegexp string
 	toRegexp   string
+	encOverr   string
 	dry        bool
 )
 
@@ -43,6 +45,7 @@ func init() {
 	flaggy.String(&toStr, "e", "end", "end at HH:MM:SS")
 	flaggy.String(&fromRegexp, "sr", "startRegexp", "start from regular expression")
 	flaggy.String(&toRegexp, "er", "endRegexp", "end at regular expression")
+	flaggy.String(&encOverr, "enc", "encoding", "override encoding detection")
 	flaggy.Bool(&dry, "d", "dry", "dry run")
 	flaggy.SetVersion(version)
 	flaggy.Parse()
@@ -175,12 +178,24 @@ func walker(realPath string, f os.FileInfo, err error) error {
 			return nil
 		}
 		// Detect the encoding
-		encoding, name, certain := charset.DetermineEncoding(subFile, "")
+		var fileEncoding encoding.Encoding
+		var name string
+		var certain bool
+		if encOverr != "" {
+			fileEncoding, name = charset.Lookup(encOverr)
+			if fileEncoding == nil {
+				fmt.Printf("Encoding %s is not recognized\n", encOverr)
+				return nil
+			}
+			certain = true
+		} else {
+			fileEncoding, name, certain = charset.DetermineEncoding(subFile, "")
+		}
 		if !certain {
 			fmt.Printf("Warning: uncertain encoding detected for %s, assuming %s\n", realPath, name)
 		}
 		// Transcode to UTF-8
-		utf8Bytes, _, err := transform.Bytes(encoding.NewDecoder(), subFile)
+		utf8Bytes, _, err := transform.Bytes(fileEncoding.NewDecoder(), subFile)
 		if err != nil {
 			fmt.Println(err)
 			return nil


### PR DESCRIPTION
Some of my files are not autodetected correctly and fallback to the wrong encoding. Allowing to specify the encoding to use would be convenient. This PR adds `-enc/--encoding []` as an option to do that.