### PR TITLE
Add automated cross-platform release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+
+      - name: Verify tag points to main
+        run: |
+          git fetch origin main --depth=1
+          git merge-base --is-ancestor "${GITHUB_SHA}" origin/main
+
+      - uses: actions/setup-go@v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Test
+        run: go test ./...
+
+      - name: Build
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: make all
+
+      - uses: softprops/action-gh-release@v3.0.0
+        with:
+          files: dist/*
+          generate_release_notes: true

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ GOOSX		= darwin
 GOOSLINUX	= linux
 
 WINBIN 		= $(DIR)/$(EXECUTABLE)-win-$(GOARCH).exe
-OSXBIN 		= $(DIR)/$(EXECUTABLE)-darwin-$(GOARCH)
+OSXBIN 		= $(DIR)/$(EXECUTABLE)-darwin-universal
+OSXAMD64	= $(DIR)/.$(EXECUTABLE)-darwin-amd64
+OSXARM64	= $(DIR)/.$(EXECUTABLE)-darwin-arm64
 LINUXBIN 	= $(DIR)/$(EXECUTABLE)-linux-$(GOARCH)
 
 CC 			= go build
@@ -23,11 +25,19 @@ all: darwin linux win64
 
 .PHONY: darwin
 darwin: $(OSXBIN)
-	chmod +x $(OSXBIN)
 
-.PHONY: $(OSXBIN)
-$(OSXBIN):
-	GOARCH=$(GOARCH) GOOS=$(GOOSX) $(CC) -o $(OSXBIN) -ldflags="$(LDFLAGS)"
+$(OSXAMD64):
+	@mkdir -p $(DIR)
+	GOARCH=amd64 GOOS=$(GOOSX) $(CC) -o $(OSXAMD64) -ldflags="$(LDFLAGS)"
+
+$(OSXARM64):
+	@mkdir -p $(DIR)
+	GOARCH=arm64 GOOS=$(GOOSX) $(CC) -o $(OSXARM64) -ldflags="$(LDFLAGS)"
+
+$(OSXBIN): $(OSXAMD64) $(OSXARM64)
+	lipo -create -output $(OSXBIN) $(OSXAMD64) $(OSXARM64)
+	rm -f $(OSXAMD64) $(OSXARM64)
+	chmod +x $(OSXBIN)
 
 .PHONY: linux
 linux: $(LINUXBIN)

--- a/Makefile_windows
+++ b/Makefile_windows
@@ -19,7 +19,8 @@ LDFLAGS		= all=-w -s -X main.version=$(VERSION)
 
 default: all
 
-all: darwin linux win64
+# ponytail: darwin-universal needs lipo (macOS); use Makefile on Mac for `make darwin`
+all: linux win64
 
 .PHONY: darwin
 darwin: $(OSXBIN)


### PR DESCRIPTION
## Summary
- Add a GitHub Actions release workflow triggered by `v*.*.*` tags on `main`, with a check that the tagged commit is on `main`
- Build and publish Linux, Windows, and macOS binaries; macOS ships as a universal binary (`ass-shifter-darwin-universal`) for Intel and Apple Silicon
- Use current stable actions: `actions/checkout@v6.0.3`, `actions/setup-go@v6.4.0`, `softprops/action-gh-release@v3.0.0`

## Test plan
- [ ] Merge PR
- [ ] Push a semver tag on `main` (e.g. `v1.2.2`) and confirm the Release workflow runs on `macos-latest`
- [ ] Verify release assets: `ass-shifter-linux-amd64`, `ass-shifter-darwin-universal`, `ass-shifter-win-amd64.exe`
- [ ] On Apple Silicon Mac, run `./ass-shifter-darwin-universal --version` without Rosetta
- [ ] On Intel Mac, run the same universal binary natively
